### PR TITLE
Update Nav and Subtitle styles for layout improvements

### DIFF
--- a/src/Components/Nav/styles.tsx
+++ b/src/Components/Nav/styles.tsx
@@ -156,6 +156,7 @@ export const NavSocialLink = styled.a`
 
 export const NavTitleContainer = styled(FlexCol)`
   align-items: flex-start;
+  height: 100px;
 `;
 
 export const NavTitle = styled.h1`

--- a/src/shared/styles.ts
+++ b/src/shared/styles.ts
@@ -36,4 +36,6 @@ export const Avatar = styled.img`
 
 export const Subtitle = styled.p`
   color: var(--muted);
+  padding-right: 5px;
+  margin: 0;
 `;


### PR DESCRIPTION
Set a fixed height for NavTitleContainer to 100px for consistent navigation layout. Added right padding and removed margin from Subtitle for better text alignment.