### PR TITLE
Remove ticker animation and image preloading from Skills

### DIFF
--- a/src/Components/Skills/Skills.tsx
+++ b/src/Components/Skills/Skills.tsx
@@ -2,7 +2,6 @@ import type { JSX } from "react";
 import * as S from "./styles";
 import { skills } from "../../data/skills";
 import SectionWrapper from "../../shared/Components/SectionWrapper/SectionWrapper";
-import { useEffect, useState } from "react";
 
 /**
  * Stock-ticker style continuous marquee for skills.
@@ -10,50 +9,50 @@ import { useEffect, useState } from "react";
  * - Pauses animation if the user prefers reduced motion.
  */
 function Skills(): JSX.Element {
-  const [tickerSkills, setTickerSkills] = useState(skills);
-  const [imagesLoaded, setImagesLoaded] = useState(false);
+  // const [tickerSkills, setTickerSkills] = useState(skills);
+  // const [imagesLoaded, setImagesLoaded] = useState(false);
 
-  // Preload all skill images before rendering the ticker
-  useEffect(() => {
-    let loaded = 0;
-    skills.forEach((s) => {
-      const img = new Image();
-      img.src = s.src;
-      img.onload = img.onerror = () => {
-        loaded += 1;
-        if (loaded === skills.length) {
-          setImagesLoaded(true);
-        }
-      };
-    });
-  }, []);
+  // // Preload all skill images before rendering the ticker
+  // useEffect(() => {
+  //   let loaded = 0;
+  //   skills.forEach((s) => {
+  //     const img = new Image();
+  //     img.src = s.src;
+  //     img.onload = img.onerror = () => {
+  //       loaded += 1;
+  //       if (loaded === skills.length) {
+  //         setImagesLoaded(true);
+  //       }
+  //     };
+  //   });
+  // }, []);
 
-  useEffect(() => {
-    if (!imagesLoaded) return;
-    const interval = setInterval(() => {
-      setTickerSkills((prev) => {
-        if (prev.length === 0) return prev;
-        const [first, ...rest] = prev;
-        return [...rest, first];
-      });
-    }, 2000);
-    return () => clearInterval(interval);
-  }, [imagesLoaded]);
+  // useEffect(() => {
+  //   if (!imagesLoaded) return;
+  //   const interval = setInterval(() => {
+  //     setTickerSkills((prev) => {
+  //       if (prev.length === 0) return prev;
+  //       const [first, ...rest] = prev;
+  //       return [...rest, first];
+  //     });
+  //   }, 2000);
+  //   return () => clearInterval(interval);
+  // }, [imagesLoaded]);
 
-  if (!imagesLoaded) {
-    return (
-      <SectionWrapper id="skills" title="Skills">
-        <div>Loading skills...</div>
-      </SectionWrapper>
-    );
-  }
+  // if (!imagesLoaded) {
+  //   return (
+  //     <SectionWrapper id="skills" title="Skills">
+  //       <div>Loading skills...</div>
+  //     </SectionWrapper>
+  //   );
+  // }
 
   return (
     <SectionWrapper id="skills" title="Skills">
       <S.Ticker aria-label="Skills ticker" role="region" aria-live="off">
         <S.TickerTrack>
           <S.TickerGroup>
-            {tickerSkills.map((s, i) => (
+            {skills.map((s, i) => (
               <S.TickerItem key={`a-${s.alt}-${i}`}>
                 <img src={s.src} alt={s.alt} loading="lazy" />
               </S.TickerItem>

--- a/src/Components/Skills/styles.tsx
+++ b/src/Components/Skills/styles.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const Ticker = styled.div`
-  overflow: hidden;
+  overflow: wrap;
   width: 100%;
   padding: 0.5rem 0;
 `;
@@ -10,7 +10,8 @@ export const TickerTrack = styled.div`
   display: flex;
   gap: 15px;
   align-items: center;
-  will-change: transform;
+  flex-wrap: wrap;
+  /* will-change: transform;
   animation: ticker 2s ease-in-out infinite;
 
   @keyframes ticker {
@@ -20,7 +21,7 @@ export const TickerTrack = styled.div`
     to {
       transform: translateX(-230px);
     }
-  }
+  } */
 `;
 
 export const TickerItem = styled.div`
@@ -29,7 +30,6 @@ export const TickerItem = styled.div`
   align-items: center;
   img {
     height: 25px;
-    width: 100px;
     display: block;
   }
 `;
@@ -38,4 +38,5 @@ export const TickerGroup = styled.div`
   display: flex;
   gap: 15px;
   align-items: center;
+  flex-wrap: wrap;
 `;


### PR DESCRIPTION
Commented out the ticker animation logic and image preloading in the Skills component, and updated styles to use flex-wrap instead of animation. This simplifies the Skills section to display all skills without animation or loading state.